### PR TITLE
[Release] Bump version to 1.0.0-alpha.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-alpha.x
+v1.0.0-alpha.4
 
 ### Breaking Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio-traitgen"
-version = "1.0.0a3"
+version = "1.0.0a4"
 requires-python = ">=3.7"
 
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,9 @@ from setuptools import setup, find_packages
 
 setup(
     name="openassetio-traitgen",
-    version="1.0.0-alpha.1",
     packages=find_packages(where="python"),
     package_dir={"": "python"},
     include_package_data=True,
-    python_requires=">=3.7",
     install_requires=["jinja2==3.1.2", "pyyaml==5.4.1", "jsonschema==4.7.2"],
     entry_points={
         "console_scripts": ["openassetio-traitgen=openassetio_traitgen.__main__:main"],


### PR DESCRIPTION
Version bump to allow mediacreation to consume the new traitgen funcitonality.

I noticed we had some duplicated information between `setup.py` and `pyproject.toml`. I didn't really want to change much in `setup.py` but it seemed sketchy having the duplication, especially the version tag which was wrong. Since there's technically been a build process change i'll do a manual testpypi dev release before 

