### PR TITLE
[Lint] Standardize line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force linux style line endings.
+* text=auto eol=lf


### PR DESCRIPTION
https://github.com/OpenAssetIO/OpenAssetIO/issues/1200

explicitly set git behaviour for line endings , ensuring linux style line endings.
We noted in some cases our CI was configured with automatic end of line conversion, which cause some linting problems, especially on windows.